### PR TITLE
FIO-11869: build a fresh McpServer per request to fix concurrent-requ…

### DIFF
--- a/src/UAGProjectInterface.ts
+++ b/src/UAGProjectInterface.ts
@@ -21,6 +21,13 @@ export class UAGProjectInterface extends ProjectInterface {
     async initialize(): Promise<void> {
         await super.initialize();
         this.uagTemplate = new UAGTemplate(this.config?.responseTemplates || {});
+        this.mcpServer = await this.buildMcpServer();
+    }
+
+    // Build a fresh McpServer with all tools registered. A new instance is created
+    // per request so concurrent requests never share (and overwrite) a transport.
+    async buildMcpServer(): Promise<McpServer> {
+        const server = new McpServer({ name: 'formio-uag', version: '1.0.0' });
 
         // Get the standard UAG tools.
         const tools = await getTools(this);
@@ -33,13 +40,14 @@ export class UAGProjectInterface extends ProjectInterface {
         // Iterate and register all the tools.
         for (const tool of tools) {
             if (tool?.name) {
-                this.mcpServer.registerTool(tool.name, {
+                server.registerTool(tool.name, {
                     title: tool.title,
                     description: tool.description,
                     inputSchema: tool.inputSchema
                 }, tool.execute);
             }
         }
+        return server;
     }
 
     addForm(form: Form, machineName: string): UAGFormInterface | undefined {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,6 @@
 import { Router, Response } from 'express';
 import { UAGProjectInterface } from './UAGProjectInterface';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
 // Helper function to create JSON RPC error responses
 const createJsonRpcErrorResponse = (code: number, message: string) => {
@@ -32,23 +31,34 @@ const handleResponseError = (error: unknown, res: Response): boolean => {
     return false;
 };
 
+/**
+ * Build a per-request McpServer + transport (stateless mode) and tear both down
+ * when the response closes. A fresh instance per request keeps concurrent requests
+ * from overwriting each other's transport.
+ */
+const connectMcpTransport = async (
+    project: UAGProjectInterface,
+    res: Response,
+): Promise<StreamableHTTPServerTransport> => {
+    const server = await project.buildMcpServer();
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,  // Use "undefined" to trigger stateless mode.
+    });
+    res.on('close', () => {
+        transport.close();
+        server.close();
+    });
+    await server.connect(transport);
+    return transport;
+};
+
 export function UAGRouter(project: UAGProjectInterface): Router {
     const router: Router = Router();
 
     // Handles the MCP post requests.
     router.post('/', async (req, res) => {
         try {
-            const transport = new StreamableHTTPServerTransport({
-                sessionIdGenerator: undefined,  // Use "undefined" to trigger stateless mode.
-            });
-            // Close any existing connection before connecting to a new transport (required in SDK 1.26.0+)
-            await project.mcpServer.close();
-            await project.mcpServer.connect(transport);
-            if (!transport) {
-                res.status(500).json(JSON.parse(createJsonRpcErrorResponse(-32603, "Unable to create MCP transport.")));
-                return;
-            }
-            isInitializeRequest(req.body);
+            const transport = await connectMcpTransport(project, res);
             await transport.handleRequest(req as any, res as any, req.body);
         } catch (error) {
             handleResponseError(error, res);
@@ -58,16 +68,7 @@ export function UAGRouter(project: UAGProjectInterface): Router {
     // Handles the MCP get requests (for health checks, etc).
     router.get('/', async (req, res) => {
         try {
-            const transport = new StreamableHTTPServerTransport({
-                sessionIdGenerator: undefined,  // Use "undefined" to trigger stateless mode.
-            });
-            // Close any existing connection before connecting to a new transport (required in SDK 1.26.0+)
-            await project.mcpServer.close();
-            await project.mcpServer.connect(transport);
-            if (!transport) {
-                res.status(500).json(JSON.parse(createJsonRpcErrorResponse(-32603, "Unable to create MCP transport.")));
-                return;
-            }
+            const transport = await connectMcpTransport(project, res);
             await transport.handleRequest(req as any, res as any);
         } catch (err) {
             handleResponseError(err, res);

--- a/test/UAGRouter.test.ts
+++ b/test/UAGRouter.test.ts
@@ -2,20 +2,62 @@ import { expect } from 'chai';
 import { Router } from 'express';
 import { UAGRouter } from '../src/router';
 
+// A fake per-request MCP server that records its lifecycle calls, so the
+// isolation tests can observe whether the router builds/disposes one per request.
+interface FakeServer {
+    connectCalls: number;
+    closeCalls: number;
+    connect(): void;
+    close(): void;
+}
+
 describe('UAGRouter', () => {
     let mockProject: any;
     let router: Router;
 
-    beforeEach(() => {
-        // Mock MCP Server
-        const mockMcpServer = {
-            close: () => { },
-            connect: () => { }
+    // Mock res that captures the 'close' listener the router registers for teardown,
+    // so tests can trigger it via res.emit('close').
+    function makeRes(overrides: any = {}) {
+        const listeners: Record<string, Array<() => void>> = {};
+        const res: any = {
+            on: (event: string, cb: () => void) => {
+                (listeners[event] ||= []).push(cb);
+                return res;
+            },
+            emit: (event: string) => {
+                (listeners[event] || []).forEach((cb) => cb());
+            },
+            status: () => res,
+            json: () => res,
+            send: () => res,
+            set: () => res,
+            writeHead: () => res,
+            end: () => res,
         };
+        return Object.assign(res, overrides);
+    }
 
-        // Mock project
+    function postHandle(r: Router = router) {
+        const postRoute = r.stack.find((layer: any) =>
+            layer.route && layer.route.path === '/' && layer.route.methods.post
+        ) as any;
+        return postRoute.route.stack[0].handle;
+    }
+
+    function getHandle(r: Router = router) {
+        const getRoute = r.stack.find((layer: any) =>
+            layer.route && layer.route.path === '/' && layer.route.methods.get
+        ) as any;
+        return getRoute.route.stack[0].handle;
+    }
+
+    beforeEach(() => {
+        // Each request builds its own MCP server; default to harmless no-ops.
         mockProject = {
-            mcpServer: mockMcpServer
+            buildMcpServer: () => ({
+                connect: () => { },
+                close: () => { },
+            }),
         };
 
         router = UAGRouter(mockProject);
@@ -46,10 +88,10 @@ describe('UAGRouter', () => {
     describe('POST / route', () => {
         it('handles MCP requests', async () => {
             let connectCalled = false;
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                connectCalled = true;
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { connectCalled = true; },
+                close: () => { },
+            });
 
             const mockReq: any = {
                 body: {
@@ -58,24 +100,11 @@ describe('UAGRouter', () => {
                     params: {}
                 }
             };
-            const mockRes: any = {
-                status: () => mockRes,
-                json: () => mockRes,
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
 
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
-
-            if (postRoute && postRoute.route) {
-                try {
-                    await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-                } catch (error) {
-                    // Expected to throw because of mock transport
-                }
+            try {
+                await postHandle()(mockReq, makeRes(), () => { });
+            } catch (error) {
+                // Expected to throw because of mock transport
             }
 
             expect(connectCalled).to.be.true;
@@ -85,35 +114,18 @@ describe('UAGRouter', () => {
             let statusCode = 0;
             let responseBody: any = null;
 
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                throw new Error('Connection failed');
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { throw new Error('Connection failed'); },
+                close: () => { },
+            });
 
-            const mockReq: any = {
-                body: {}
-            };
-            const mockRes: any = {
-                status: (code: number) => {
-                    statusCode = code;
-                    return mockRes;
-                },
-                json: (body: any) => {
-                    responseBody = body;
-                    return mockRes;
-                },
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
+            const mockReq: any = { body: {} };
+            const mockRes = makeRes({
+                status: (code: number) => { statusCode = code; return mockRes; },
+                json: (body: any) => { responseBody = body; return mockRes; },
+            });
 
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
-
-            if (postRoute && postRoute.route) {
-                await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-            }
+            await postHandle()(mockReq, mockRes, () => { });
 
             expect(statusCode).to.equal(500);
             expect(responseBody).to.have.property('error');
@@ -123,30 +135,15 @@ describe('UAGRouter', () => {
     describe('GET / route', () => {
         it('handles GET requests', async () => {
             let connectCalled = false;
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                connectCalled = true;
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { connectCalled = true; },
+                close: () => { },
+            });
 
-            const mockReq: any = {};
-            const mockRes: any = {
-                status: () => mockRes,
-                json: () => mockRes,
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
-
-            const getRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.get
-            );
-
-            if (getRoute && getRoute.route) {
-                try {
-                    await getRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-                } catch (error) {
-                    // Expected to throw because of mock transport
-                }
+            try {
+                await getHandle()({} as any, makeRes(), () => { });
+            } catch (error) {
+                // Expected to throw because of mock transport
             }
 
             expect(connectCalled).to.be.true;
@@ -154,30 +151,15 @@ describe('UAGRouter', () => {
 
         it('connects MCP server on GET request', async () => {
             let transportConnected = false;
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                transportConnected = true;
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { transportConnected = true; },
+                close: () => { },
+            });
 
-            const mockReq: any = {};
-            const mockRes: any = {
-                status: () => mockRes,
-                json: () => mockRes,
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
-
-            const getRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.get
-            );
-
-            if (getRoute && getRoute.route) {
-                try {
-                    await getRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-                } catch (error) {
-                    // Expected
-                }
+            try {
+                await getHandle()({} as any, makeRes(), () => { });
+            } catch (error) {
+                // Expected
             }
 
             expect(transportConnected).to.be.true;
@@ -188,7 +170,6 @@ describe('UAGRouter', () => {
         it('handles Response instance errors', async () => {
             let statusCode = 0;
             let headers: any = {};
-            let responseText = '';
 
             // Create a mock Response error
             const mockResponseError = new Response('Forbidden', {
@@ -199,39 +180,23 @@ describe('UAGRouter', () => {
                 })
             });
 
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                throw mockResponseError;
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { throw mockResponseError; },
+                close: () => { },
+            });
 
             const mockReq: any = { body: {} };
-            const mockRes: any = {
-                status: (code: number) => {
-                    statusCode = code;
-                    return mockRes;
-                },
+            const mockRes = makeRes({
+                status: (code: number) => { statusCode = code; return mockRes; },
                 set: (h: any) => {
                     if (typeof h === 'object') {
                         headers = { ...headers, ...h };
                     }
                     return mockRes;
                 },
-                send: (text: string) => {
-                    responseText = text;
-                    return mockRes;
-                },
-                json: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
+            });
 
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
-
-            if (postRoute && postRoute.route) {
-                await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-            }
+            await postHandle()(mockReq, mockRes, () => { });
 
             expect(statusCode).to.equal(403);
             expect(headers['content-type'] || headers['Content-Type']).to.equal('application/json');
@@ -242,33 +207,18 @@ describe('UAGRouter', () => {
             let statusCode = 0;
             let responseBody: any = null;
 
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                throw new Error('Generic error');
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { throw new Error('Generic error'); },
+                close: () => { },
+            });
 
             const mockReq: any = { body: {} };
-            const mockRes: any = {
-                status: (code: number) => {
-                    statusCode = code;
-                    return mockRes;
-                },
-                json: (body: any) => {
-                    responseBody = body;
-                    return mockRes;
-                },
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
+            const mockRes = makeRes({
+                status: (code: number) => { statusCode = code; return mockRes; },
+                json: (body: any) => { responseBody = body; return mockRes; },
+            });
 
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
-
-            if (postRoute && postRoute.route) {
-                await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-            }
+            await postHandle()(mockReq, mockRes, () => { });
 
             expect(statusCode).to.equal(500);
             expect(responseBody).to.have.property('error');
@@ -279,30 +229,17 @@ describe('UAGRouter', () => {
         it('includes jsonrpc version in error response', async () => {
             let responseBody: any = null;
 
-            mockProject.mcpServer.close = () => {};
-            mockProject.mcpServer.connect = () => {
-                throw new Error('Test error');
-            };
+            mockProject.buildMcpServer = () => ({
+                connect: () => { throw new Error('Test error'); },
+                close: () => { },
+            });
 
             const mockReq: any = { body: {} };
-            const mockRes: any = {
-                status: () => mockRes,
-                json: (body: any) => {
-                    responseBody = body;
-                    return mockRes;
-                },
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
+            const mockRes = makeRes({
+                json: (body: any) => { responseBody = body; return mockRes; },
+            });
 
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
-
-            if (postRoute && postRoute.route) {
-                await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
-            }
+            await postHandle()(mockReq, mockRes, () => { });
 
             expect(responseBody).to.have.property('jsonrpc', '2.0');
             expect(responseBody.error).to.have.property('code', -32603);
@@ -315,38 +252,78 @@ describe('UAGRouter', () => {
             // This test verifies that the router is configured for stateless mode
             // by checking that sessionIdGenerator is undefined
             const mockReq: any = { body: {} };
-            const mockRes: any = {
-                status: () => mockRes,
-                json: () => mockRes,
-                send: () => mockRes,
-                writeHead: () => mockRes,
-                end: () => mockRes
-            };
-
-            const postRoute = router.stack.find((layer: any) =>
-                layer.route && layer.route.path === '/' && layer.route.methods.post
-            );
 
             // The test passes if no errors are thrown related to session management
-            if (postRoute && postRoute.route) {
+            try {
+                await postHandle()(mockReq, makeRes(), () => { });
+            } catch (error) {
+                // Expected to throw due to mock, but not session-related
+                expect((error as Error).message).to.not.include('session');
+            }
+        });
+    });
+
+    describe('per-request MCP server isolation (FIO-11869)', () => {
+        // Build a project whose buildMcpServer() hands out a fresh, call-recording
+        // server each time, so we can assert one server is built (and torn down) per request.
+        function trackedProject() {
+            const built: FakeServer[] = [];
+            const project: any = {
+                buildMcpServer: () => {
+                    const server: FakeServer = {
+                        connectCalls: 0,
+                        closeCalls: 0,
+                        connect() { this.connectCalls++; },
+                        close() { this.closeCalls++; },
+                    };
+                    built.push(server);
+                    return server;
+                },
+            };
+            return { project, built };
+        }
+
+        it('builds an isolated MCP server for each request instead of sharing one', async () => {
+            const { project, built } = trackedProject();
+            const handle = postHandle(UAGRouter(project));
+
+            for (let i = 0; i < 3; i++) {
+                const mockReq: any = { body: { jsonrpc: '2.0', method: 'tools/call', params: {} } };
                 try {
-                    await postRoute.route.stack[0].handle(mockReq, mockRes, () => {});
+                    await handle(mockReq, makeRes(), () => { });
                 } catch (error) {
-                    // Expected to throw due to mock, but not session-related
-                    expect((error as Error).message).to.not.include('session');
+                    // The real transport rejects against the mock res; irrelevant here.
                 }
             }
+
+            expect(built.length).to.equal(3);
+        });
+
+        it('disposes the per-request MCP server when the response closes', async () => {
+            const { project, built } = trackedProject();
+            const handle = postHandle(UAGRouter(project));
+            const mockRes = makeRes();
+
+            const mockReq: any = { body: { jsonrpc: '2.0', method: 'tools/call', params: {} } };
+            try {
+                await handle(mockReq, mockRes, () => { });
+            } catch (error) {
+                // expected
+            }
+
+            expect(built.length).to.equal(1);
+            mockRes.emit('close');
+            expect(built[0].closeCalls).to.be.greaterThan(0);
         });
     });
 
     describe('router integration', () => {
         it('accepts different project configurations', () => {
             const customProject: any = {
-                mcpServer: {
-                    close: () => { },
+                buildMcpServer: () => ({
                     connect: () => { },
-                    registerTool: () => { }
-                }
+                    close: () => { },
+                }),
             };
 
             const customRouter = UAGRouter(customProject);


### PR DESCRIPTION
The endpoint reused one shared McpServer across all requests, so concurrent requests overwrote each other's transport and their responses were silently dropped — only one request worked at a time. Now each request gets its own McpServer + transport, disposed when the response closes. Covers POST and GET; adds tests.
I used this script to test the solution manually.

### Verifying locally

Requires Docker. The published `formio/uag` image has no fix — rebuild it.

```sh
# 1. build dev image (from apps/uag)
docker build -t formio/uag:dev .

# 2. sandbox stack: mongo + formio
#    (apps/uag/examples/local — set image: formio/uag:dev on formio-uag first)
docker compose up -d          # MCp

# 3. get a token: log in once via the proxy, then copy access_token from
#    ~/.mcp-auth/mcp-remote-<ver>/
npx mcp-remote http://localhost:3000/mcp
#    (create an Employee in the OSS portal at :3000 and log in with it)

# 4. run the script → expect ok=N
node uag-live-concurrency.mjs
```

<details>
<summary>Concurrency verification script (node uag-live-concurrency.mjs)</summary>

```js
/**
 * FIO-11869: N concurrent tools/call against the live formio/uag:dev container
 * (per-request pattern) via nginx at :3000/mcp. Expect ok=N (was ok=1 when shared).
 */
const BASE = 'http://localhost:3000';
// Local sandbox OAuth token from pe=formio.
const TOKEN = ' !!!! YOUR TOKEN !!!!!'

const CONCURRENCY = 50;
const ACCEPT = 'application/json,

function extractResult(rawBody) {
  const chunks = [];
  for (const line of rawBody.split(/\r?\n/)) {
    if (line.startsWith('data:')) {
      try {
        chunks.push(JSON.parse(line.slice(5).trim()));
      } catch {}
    }
  }
  if (chunks.length === 0 && rawBody.trim()) {
    try {
      chunks.push(JSON.parse(rawBody));
    } catch {}
  }
  return chunks.find((c) => c.resu
}

async function rpc(body) {
  const resp = await fetch(`${BASE}/mcp`, {
    method: 'POST',
    headers: {
      'Content-Type': 'application
      Accept: ACCEPT,
      Authorization: `Bearer ${TOK
    },
    body: JSON.stringify(body),
  });
  const text = await resp.text();
  return { status: resp.status, rew: text };
}

async function main() {
  const calls = Array.from({ length: CONCURRENCY }, (_, i) =>
    (async () => {
      await rpc({
        jsonrpc: '2.0',
        id: `init-${i}`,
        method: 'initialize',
        params: {
          protocolVersion: '2025-0
          capabilities: {},
          clientInfo: { name: `client-${i}`, version: '1.0.0' },
        },
      });
      const r = await rpc({
        jsonrpc: '2.0',
        id: `call-${i}`,
        method: 'tools/call',
        params: { name: 'find_submame: 'customer' } },
      });
      return { i, ...r };
    })(),
  );

  const results = await Promise.all(calls);

  console.log(`\nFIO-11869 live: ${CONCURRENCY} concurrent tools/call vs formio/uag:dev (uag with
new changes for FIO-11869 )`);
  let ok = 0;
  let broken = 0;
  for (const r of results) {
    const hasResult = !!r.result?.result;
    if (hasResult) ok++;
    else broken++;
    console.log(`  client${r.i}  hResult ? 'Y' : 'N'}`);
  }
  console.log(`\ntotal=${CONCURRENn}`);
  console.log(broken === 0 ? '  all responses delivered' : `  ${broken} lost — is the container on
:dev?`);
  process.exit(0);
}

main().catch((e) => {
  console.error(e);
  process.exit(1);
});
```

</details>